### PR TITLE
Bugfix: PHP on internal webserver + win + env ANSICON set

### DIFF
--- a/Dumper/CliDumper.php
+++ b/Dumper/CliDumper.php
@@ -58,7 +58,7 @@ class CliDumper extends AbstractDumper
     {
         parent::__construct($output, $charset);
 
-        if ('\\' === DIRECTORY_SEPARATOR && false !== @getenv('ANSICON')) {
+        if ('\\' === DIRECTORY_SEPARATOR && false !== @getenv('ANSICON') && 'cli' === PHP_SAPI) {
             // Use only the base 16 xterm colors when using ANSICON
             $this->setStyles(array(
                 'default' => '31',


### PR DESCRIPTION
This fixes a bug with formatted output (formatted for CLI instead Web) when running PHP on internal webserver on windows with having ANSICON set.